### PR TITLE
Update `ecma-sl` to track main

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -15,22 +15,30 @@ let non_dir_fpath = (parse_fpath Bos.OS.File.exists, Fpath.pp)
 
 let _dir_fpath = (parse_fpath Bos.OS.Dir.exists, Fpath.pp)
 
+let debug =
+  let doc = "Run in debug mode" in
+  Arg.(value & flag & info [ "debug" ] ~doc)
+
 let input =
   let docv = "FILE" in
   let doc = "Name of the input file." in
-  Arg.(required & pos 0 (some non_dir_fpath) None & info [] ~doc ~docv)
+  Arg.(required & pos 0 (some non_dir_fpath) None & info [] ~docv ~doc)
 
 let filename =
+  let docv = "FILE" in
   let doc = "Overwrite input file in taint_summary" in
-  Arg.(value & opt (some fpath) None & info [ "filename" ] ~doc)
+  Arg.(value & opt (some fpath) None & info [ "filename" ] ~docv ~doc)
 
 let workspace_dir =
+  let docv = "DIR" in
   let doc = "Directory to store intermediate results" in
-  Arg.(value & opt fpath (Fpath.v "explode-out") & info [ "workspace" ] ~doc)
+  Arg.(
+    value & opt fpath (Fpath.v "explode-out") & info [ "workspace" ] ~docv ~doc )
 
 let time_limit =
+  let docv = "VAL" in
   let doc = "Maximum time limit for analysis" in
-  Arg.(value & opt float 0.0 & info [ "timeout" ] ~doc)
+  Arg.(value & opt float 0.0 & info [ "timeout" ] ~docv ~doc)
 
 let cmd_run =
   let doc = "Explode.js symbolic vulnerability confirmation engine" in
@@ -46,7 +54,9 @@ let cmd_run =
     ]
   in
   let options =
-    Term.(const Cmd_run.options $ input $ filename $ workspace_dir $ time_limit)
+    Term.(
+      const Cmd_run.options $ debug $ input $ filename $ workspace_dir
+      $ time_limit )
   in
   let info = Cmd.info "run" ~doc ~sdocs ~exits ~man ~man_xrefs in
   Cmd.v info Term.(const Cmd_run.main $ options)
@@ -58,7 +68,7 @@ let cmd_exploit =
   let man = [ `S Manpage.s_description; `P description ] in
   let man_xrefs = [] in
   let options =
-    Term.(const Cmd_exploit.options $ input $ workspace_dir $ time_limit)
+    Term.(const Cmd_exploit.options $ debug $ input $ workspace_dir $ time_limit)
   in
   let info = Cmd.info "exploit" ~doc ~sdocs ~man ~man_xrefs in
   Cmd.v info Term.(const Cmd_exploit.main $ options)

--- a/bin/cmd_exploit.ml
+++ b/bin/cmd_exploit.ml
@@ -1,12 +1,14 @@
-open EslBase.Syntax.Result
+open Smtml.Syntax.Result
 
 type options =
-  { filename : Fpath.t
+  { debug : bool
+  ; filename : Fpath.t
   ; workspace : Fpath.t
   ; time_limit : float
   }
 
-let options filename workspace time_limit = { filename; workspace; time_limit }
+let options debug filename workspace time_limit =
+  { debug; filename; workspace; time_limit }
 
 let run_with_timeout limit f =
   let exception Sigchld in
@@ -33,12 +35,14 @@ let run_with_timeout limit f =
       | WSIGNALED _ | WSTOPPED _ -> `Timeout
   end
 
-let run ({ filename = test; workspace; time_limit } : options) =
+let run ({ debug; filename = test; workspace; time_limit } : options) =
   let* _ = Bos.OS.Dir.create workspace in
   let workspace = Fpath.(workspace // rem_ext (base test)) in
   let work () =
     let n =
-      Cmd_symbolic.main { filename = test; entry_func = "main"; workspace } ()
+      Cmd_symbolic.main
+        { debug; filename = test; entry_func = "main"; workspace }
+        ()
     in
     if n <> 0 then n else Cmd_replay.main { filename = test; workspace } ()
   in

--- a/bin/cmd_exploit.mli
+++ b/bin/cmd_exploit.mli
@@ -1,9 +1,10 @@
 type options =
-  { filename : Fpath.t
+  { debug : bool
+  ; filename : Fpath.t
   ; workspace : Fpath.t
   ; time_limit : float
   }
 
-val options : Fpath.t -> Fpath.t -> float -> options
+val options : bool -> Fpath.t -> Fpath.t -> float -> options
 
 val main : options -> int

--- a/bin/cmd_run.ml
+++ b/bin/cmd_run.ml
@@ -1,15 +1,16 @@
 open I2
-open Ecma_sl.Syntax.Result
+open Smtml.Syntax.Result
 
 type options =
-  { config : Fpath.t
+  { debug : bool
+  ; config : Fpath.t
   ; filename : Fpath.t option
   ; workspace_dir : Fpath.t
   ; time_limit : float
   }
 
-let options config filename workspace_dir time_limit =
-  { config; filename; workspace_dir; time_limit }
+let options debug config filename workspace_dir time_limit =
+  { debug; config; filename; workspace_dir; time_limit }
 
 let get_tests workspace (config : Fpath.t) (filename : Fpath.t option) =
   let file = Option.map Fpath.to_string filename in
@@ -42,19 +43,21 @@ let run_with_timeout limit f =
       | WSIGNALED _ | WSTOPPED _ -> `Timeout
   end
 
-let run_single ~time_limit ~(workspace : Fpath.t) (filename : Fpath.t)
+let run_single ~time_limit ~(workspace : Fpath.t) debug (filename : Fpath.t)
   original_file taint_summary : int =
   let original_file = Option.map Fpath.to_string original_file in
   let taint_summary = Fpath.to_string taint_summary in
   let f () =
-    let n = Cmd_symbolic.main { filename; entry_func = "main"; workspace } () in
+    let n =
+      Cmd_symbolic.main { debug; filename; entry_func = "main"; workspace } ()
+    in
     if n <> 0 then n
     else begin
       match
         Cmd_replay.replay ?original_file ~taint_summary filename workspace
       with
       | Error (`Msg msg) ->
-        Format.eprintf "%s" msg;
+        Logs.err (fun m -> m "%s" msg);
         1
       | Ok () -> 0
     end
@@ -65,17 +68,17 @@ let run_single ~time_limit ~(workspace : Fpath.t) (filename : Fpath.t)
   match result with
   | `Ok n -> n
   | `Timeout ->
-    Format.eprintf "warning: Reached time limit@.";
+    Logs.warn (fun m -> m "Reached time limit");
     4
 
-let run_all ({ config; filename; workspace_dir; time_limit } : options) =
+let run_all ({ debug; config; filename; workspace_dir; time_limit } : options) =
   let* _ = Bos.OS.Dir.create ~mode:0o777 workspace_dir in
   let* symbolic_tests = get_tests workspace_dir config filename in
   let rec loop = function
     | [] -> Ok 0
     | test :: remaning ->
       let workspace = Fpath.(workspace_dir // rem_ext (base test)) in
-      let n = run_single ~time_limit ~workspace test filename config in
+      let n = run_single ~time_limit ~workspace debug test filename config in
       if n <> 0 then Error (`Status n) else loop remaning
   in
   loop symbolic_tests
@@ -86,8 +89,8 @@ let main opts =
   | Error err -> (
     match err with
     | #I2.Result.err as error ->
-      Format.eprintf "error: %a@." I2.Result.pp error;
+      Logs.err (fun m -> m "%a" I2.Result.pp error);
       I2.Result.to_code error
     | `Status n ->
-      Format.eprintf "error: Failed during symbolic execution/confirmation@.";
+      Logs.err (fun m -> m "Failed during symbolic execution/confirmation");
       n )

--- a/bin/cmd_run.mli
+++ b/bin/cmd_run.mli
@@ -1,10 +1,11 @@
 type options =
-  { config : Fpath.t
+  { debug : bool
+  ; config : Fpath.t
   ; filename : Fpath.t option
   ; workspace_dir : Fpath.t
   ; time_limit : float
   }
 
-val options : Fpath.t -> Fpath.t option -> Fpath.t -> float -> options
+val options : bool -> Fpath.t -> Fpath.t option -> Fpath.t -> float -> options
 
 val main : options -> int

--- a/dune-project
+++ b/dune-project
@@ -24,30 +24,38 @@
  (synopsis "Automatic exploit generation for Node.js")
  (description "Explode.js: Automatic exploit generation engine for Node.js applications")
  (depends
-  ocaml
-  dune
-  cmdliner
   bos
-  fpath
-  yojson
+  cmdliner
+  dune
   dune-site
   ecma-sl
-  instrumentation2)
- (tags
-  ("symbolic execution" javascript exploit))
+  fpath
+  instrumentation2
+  ocaml
+  smtml
+  yojson
+  z3)
  (sites
-  (share nodejs)))
+  (share nodejs))
+ (tags
+  ("symbolic execution" javascript exploit)))
 
 (package
  (name explode_js-instrumentation)
  (synopsis "Instrumentation2")
  (description "Instrumentation2")
  (depends
-  ocaml
+  (bos
+   (>= 0.2.1))
+  (bisect_ppx
+   (and
+    :with-test
+    (>= 2.5.0)))
+  (cmdliner
+   (>= 1.2.0))
   dune
-  (cmdliner (>= 1.2.0))
-  (yojson (>= 2.1.2))
-  (bos (>= 0.2.1))
-  (bisect_ppx (and :with-test (>= 2.5.0))))
+  ocaml
+  (yojson
+   (>= 2.1.2)))
  (tags
   (javascript nodejs exploit vulnerability)))

--- a/explode_js-instrumentation.opam
+++ b/explode_js-instrumentation.opam
@@ -10,12 +10,12 @@ homepage: "https://github.com/explode-js/explode-js"
 doc: "https://url/to/documentation"
 bug-reports: "https://github.com/explode-js/explode-js/issues"
 depends: [
-  "ocaml"
-  "dune" {>= "3.15"}
-  "cmdliner" {>= "1.2.0"}
-  "yojson" {>= "2.1.2"}
   "bos" {>= "0.2.1"}
   "bisect_ppx" {with-test & >= "2.5.0"}
+  "cmdliner" {>= "1.2.0"}
+  "dune" {>= "3.15"}
+  "ocaml"
+  "yojson" {>= "2.1.2"}
   "odoc" {with-doc}
 ]
 build: [

--- a/explode_js.opam
+++ b/explode_js.opam
@@ -11,15 +11,17 @@ homepage: "https://github.com/explode-js/explode-js"
 doc: "https://url/to/documentation"
 bug-reports: "https://github.com/explode-js/explode-js/issues"
 depends: [
-  "ocaml"
-  "dune" {>= "3.15"}
-  "cmdliner"
   "bos"
-  "fpath"
-  "yojson"
+  "cmdliner"
+  "dune" {>= "3.15"}
   "dune-site"
   "ecma-sl"
+  "fpath"
   "instrumentation2"
+  "ocaml"
+  "smtml"
+  "yojson"
+  "z3"
   "odoc" {with-doc}
 ]
 build: [
@@ -39,6 +41,3 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/explode-js/explode-js.git"
-pin-depends: [
-  ["smtml.dev" "git+https://github.com/formalsec/smtml.git#d1668dbfcdcf78c076d5a3665ae051bfa348873a"]
-]

--- a/explode_js.opam.template
+++ b/explode_js.opam.template
@@ -1,3 +1,0 @@
-pin-depends: [
-  ["smtml.dev" "git+https://github.com/formalsec/smtml.git#d1668dbfcdcf78c076d5a3665ae051bfa348873a"]
-]


### PR DESCRIPTION
Updates ecma-sl vendor submodule to the latest stable commit of ecma-sl.

Adds `--debug` argument to allow ecma-sl debugging during symbolic execution.

Uses `Logs` library