### PR TITLE
Bring back ECMA-SL's development submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,7 @@ jobs:
 
       - name: Checkout Submodules
         run: |
-          git submodule update --init vendor/graphjs
-          rm -rf vendor/ECMA-SL;
-          git clone git@github.com:formalsec/ECMA-SL.git vendor/ECMA-SL
+          git submodule update --init vendor/graphjs vendor/ECMA-SL
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/NodeMedicAnalysis/NodeMedic-FINE.git
 [submodule "vendor/ECMA-SL"]
 	path = vendor/ECMA-SL
-	url = https://github.com/formalsec/ECMA-SL-pub.git
+	url = git@github.com:formalsec/ECMA-SL.git

--- a/src/core/exploit_patterns.ml
+++ b/src/core/exploit_patterns.ml
@@ -36,6 +36,9 @@ let readFile_patterns =
 
 let apply pc = function
   | `Abort _ | `Assert_failure _ | `Failure _ -> [ pc ]
-  | `Exec_failure v -> List.map (fun f -> f v :: pc) exec_patterns
-  | `Eval_failure v -> List.map (fun f -> f v :: pc) eval_patterns
-  | `ReadFile_failure v -> List.map (fun f -> f v :: pc) readFile_patterns
+  | `Exec_failure v ->
+    List.map (fun f -> Smtml.Expr.Set.add (f v) pc) exec_patterns
+  | `Eval_failure v ->
+    List.map (fun f -> Smtml.Expr.Set.add (f v) pc) eval_patterns
+  | `ReadFile_failure v ->
+    List.map (fun f -> Smtml.Expr.Set.add (f v) pc) readFile_patterns

--- a/src/core/sym_path_resolver.ml
+++ b/src/core/sym_path_resolver.ml
@@ -1,13 +1,10 @@
 open Ecma_sl_symbolic
-module Thread = Choice_monad.Thread
-module Solver = Solver
 
 let ( let* ) = Result.bind
 
-let solve (ty : Symbolic_error.t) workspace thread =
+let solve solver pc (ty : Symbolic_error.t) workspace =
   let open Result in
-  let pc = Smtml.Expr.Set.to_list @@ Thread.pc thread in
-  let solver = Thread.solver thread in
+  let pc = Smtml.Expr.Set.to_list pc in
   let pcs = Exploit_patterns.apply pc ty in
   let result =
     list_map

--- a/src/core/sym_path_resolver.ml
+++ b/src/core/sym_path_resolver.ml
@@ -4,16 +4,15 @@ let ( let* ) = Result.bind
 
 let solve solver pc (ty : Symbolic_error.t) workspace =
   let open Result in
-  let pc = Smtml.Expr.Set.to_list pc in
   let pcs = Exploit_patterns.apply pc ty in
   let result =
     list_map
       (fun pc ->
         let model =
           try
-            match Solver.check solver pc with
+            match Solver.get_sat_model solver pc with
             | `Unsat | `Unknown -> None
-            | `Sat -> Solver.model solver
+            | `Model m -> Some m
           with exn ->
             Logs.err (fun k ->
               k "solver: %s: cannot encode desired pc" (Printexc.to_string exn) );

--- a/test/exploit/test_exploit.t
+++ b/test/exploit/test_exploit.t
@@ -1,7 +1,7 @@
 Test symbolic argv:
   $ explode-js exploit --deterministic test_sink_argv.js
   ├── Symbolic execution output:
-  "":83264.2-83264.20: Assert failure:
+  "":83632.2-83632.20: Assert failure:
    Stmt: assert (hd params)
    Expr: false
   ├── ⚠ Detected 1 issue(s)!


### PR DESCRIPTION
We need to perform regression testing of explode-js with the recent changes made to ECMA-SL. Because of this I'm bringing back ECMA-SL's development submodule because current scripts checkout the submodule registered by the repo.